### PR TITLE
Broken link replaced with arxiv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,4 +181,4 @@ References
 
 Güneş Erkan and Dragomir R. Radev:
 `LexRank: Graph-based Lexical Centrality as Salience in Text Summarization
-<http://www.jair.org/papers/paper1523.html>`_.
+<https://arxiv.org/abs/1109.2128>`_.


### PR DESCRIPTION
Broken link replaced with arxiv